### PR TITLE
[update] リクエストの再送をwhile文で制御するようにした

### DIFF
--- a/nuctpy/utilities/auth.py
+++ b/nuctpy/utilities/auth.py
@@ -1,11 +1,10 @@
+import time
 from html.parser import HTMLParser
 from typing import List, Optional, Tuple
 
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
 
-from ..settings import MFA_CAS_URL
+from ..settings import MFA_CAS_URL, NUCT_ROOT
 from .totp import get_totp_token
 
 
@@ -37,7 +36,9 @@ def get_payload(html):
     return payload
 
 
-def login_with_mfa(username: str, password: str, seed: str) -> requests.Session:
+def login_with_mfa(
+    username: str, password: str, seed: str, print_log=True
+) -> requests.Session:
     """NUCTの多要素認証を突破し、認証済みCookieを持ったセッションオブジェクトを返す.
 
     Args:
@@ -53,40 +54,60 @@ def login_with_mfa(username: str, password: str, seed: str) -> requests.Session:
     session.headers[
         "User-Agent"
     ] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"  # noqa: #501
-    retries = Retry(
-        total=2,
-        backoff_factor=1,
-        allowed_methods=["POST"],
-        status_forcelist=[401, 500, 502, 503, 504],
-    )
-    session.mount("https://", HTTPAdapter(max_retries=retries))
-    session.mount("http://", HTTPAdapter(max_retries=retries))
 
-    # 認証のトップページにアクセス
-    auth_top_page = session.get(MFA_CAS_URL)
+    def id_pwd_page_hook(r: requests.Response, *args, **kwargs):
+        time.sleep(0)
+        return r
+
+    session.hooks["response"].append(id_pwd_page_hook)
+
+    # Sakaiのログイン画面にアクセス
+    auth_top_page = session.get(NUCT_ROOT + "portal/login")
     auth_top_page.raise_for_status()  # 200以外でエラー
     # formのname,valueの組を取得
     payload = get_payload(auth_top_page.text)
     payload.update({"username": username, "password": password})
-    print("top page: ", auth_top_page.status_code)
+    if print_log:
+        print("top page: ", auth_top_page.status_code)
 
     # username,passwordをpostする．多要素認証画面が返ってくる．
-    auth_token_page = session.post(MFA_CAS_URL, data=payload)
+    session.hooks["response"].append(id_pwd_page_hook)
+    auth_token_page = session.post(MFA_CAS_URL, data=payload, allow_redirects=False)
     auth_token_page.raise_for_status()  # 200以外でエラー
     payload = get_payload(auth_token_page.text)
-    print("id & password auth: ", auth_token_page.status_code)
+    if print_log:
+        print("id & password auth: ", auth_token_page.status_code)
 
-    def upload_payload(r: requests.Response, *args, **kwargs):
+    def token_page_hooks(r: requests.Response, *args, **kwargs):
         if r.status_code == 401:
             payload = get_payload(r.text)
             payload.update({"token": get_totp_token(seed)})
+            print("updated")
+        elif r.status_code == 302:  # リダイレクトにsleepを挟む
+            location = r.headers["Location"]
+            if location == "/portal":
+                r = session.get(NUCT_ROOT + location)
+            else:
+                r = session.get(location, cookies=r.cookies)
         return r
 
-    session.hooks["response"].append(upload_payload)
+    session.hooks["response"].append(token_page_hooks)
 
     # tokenを含めてpostする．nuctのトップ画面が返ってくる．
     payload.update({"token": get_totp_token(seed)})
-    nuct_top_page = session.post(MFA_CAS_URL, data=payload, timeout=(5.0, 5.0))
-    nuct_top_page.raise_for_status()  # 200以外でエラー
-    print("token auth: ", nuct_top_page.status_code)
+    count = 0
+    while count <= 8:
+        try:
+            nuct_top_page = session.post(
+                MFA_CAS_URL, data=payload, timeout=(5.0, 5.0), allow_redirects=False
+            )
+            nuct_top_page.raise_for_status()  # 200以外でエラー
+            break
+        except requests.exceptions.HTTPError as e:
+            if print_log:
+                print(e)
+            time.sleep(3)
+        count += 1
+    if print_log:
+        print("token auth: ", nuct_top_page.status_code)
     return session


### PR DESCRIPTION
- リクエストの再送をurlib3/Retryではなくwhile文で制御するようにした（間隔をあけて再送するようにしたかったのと、トークンを取得し直さないといけないため）
- リクエストの待ち時間を修正した